### PR TITLE
Add file history tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,6 @@ rust_openai = { path = "../rust_openai"}
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 toml = "0.8"
+# This could probably be a dev dependency
+mockall = "0.13"
 

--- a/bugtrack/04-file-history.md
+++ b/bugtrack/04-file-history.md
@@ -1,1 +1,13 @@
-TODO: Create me from the template
+# File history
+
+## Status: P1
+
+## Problem 
+
+The user should be able to see the history of a file. 
+I think this was partly implemented in a previous change for 
+the content store.
+
+## Design
+
+## Issue log

--- a/bugtrack/04-file-history.md
+++ b/bugtrack/04-file-history.md
@@ -8,6 +8,23 @@ The user should be able to see the history of a file.
 I think this was partly implemented in a previous change for 
 the content store.
 
+previous change was
+
+'''
+>>> wrought history myfile.md
++ cefasefs-sdfssfs 'Init from template'
++ das1asdj-dgfgasd 'Manual update'
++ degfgdh-ushdhfsu 'Manual update'
+- sdfsghs-sdfkjsdf 'Local Changes'
+'''
+
+Think what we need to do here is primarily around testing all the various cases.
+
+And this probably requires mocking the event log, and extracting the printing function core to something that returns a lost of entries. or something that takes a Writer.
+
+cases to consider are...
+
+
 ## Design
 
 ## Issue log

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -273,7 +273,7 @@ pub mod test {
         let mut event_log = MockEventLog::default();
         event_log
             .expect_get_last_write_event()
-            .returning(|p| Ok(None));
+            .returning(|_| Ok(None));
 
         assert_eq!(
             event_log

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -245,3 +245,41 @@ impl DummyEventLog {
         }
     }
 }
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::*;
+    use mockall::mock;
+
+    mock! {
+        pub EventLog {}
+
+        impl EventLog for EventLog {
+            fn get_last_write_event(&self, p: &Path) -> anyhow::Result<Option<Event>>;
+            fn get_file_history(&self, p: &Path) -> anyhow::Result<Vec<Event>>;
+            fn get_event_group(&self, group_id: u64) -> anyhow::Result<Option<EventGroup>>;
+            fn add_event_group(&mut self, group: &EventGroup) -> anyhow::Result<EventGroup>;
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use std::path::PathBuf;
+
+    use super::{test_utils::MockEventLog, EventLog};
+
+    pub fn check_mocking_works() {
+        let mut event_log = MockEventLog::default();
+        event_log
+            .expect_get_last_write_event()
+            .returning(|p| Ok(None));
+
+        assert_eq!(
+            event_log
+                .get_last_write_event(&PathBuf::from("hello"))
+                .unwrap(),
+            None
+        );
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -4,7 +4,7 @@ use crate::binary16::ContentHash;
 use crate::metadata::MetadataEntry;
 use crate::metadata::MetadataKey;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Event {
     pub id: u64,
     pub group_id: u64,
@@ -18,7 +18,7 @@ impl Event {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum EventType {
     WriteFile(WriteFileEvent),
     ReadFile(ReadFileEvent),
@@ -27,7 +27,7 @@ pub enum EventType {
 }
 
 // Can actually represent create/modify/delete
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WriteFileEvent {
     pub path: PathBuf,
     pub before_hash: Option<ContentHash>,
@@ -35,20 +35,20 @@ pub struct WriteFileEvent {
 }
 
 // When called on a missing file, hash=None
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReadFileEvent {
     pub path: PathBuf,
     pub hash: Option<ContentHash>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GetMetadataEvent {
     pub path: PathBuf,
     pub key: MetadataKey,
     pub value: Option<MetadataEntry>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SetMetadataEvent {
     pub path: PathBuf,
     pub key: MetadataKey,

--- a/src/file_history.rs
+++ b/src/file_history.rs
@@ -3,7 +3,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-
 use crate::{binary16::ContentHash, event_log::EventLog, events::EventType};
 
 #[derive(Debug, PartialEq)]
@@ -80,7 +79,10 @@ pub fn file_history(
 #[cfg(test)]
 pub mod test {
     use std::{
-        any, io::Cursor, path::PathBuf, sync::{Arc, Mutex}
+        any,
+        io::Cursor,
+        path::PathBuf,
+        sync::{Arc, Mutex},
     };
 
     use anyhow::anyhow;
@@ -145,12 +147,13 @@ pub mod test {
                 .returning(move |_| Ok(None));
         }
 
-        pub fn with_read_error<P: Into<PathBuf>, F>(&mut self, path: P, f: F) 
-        where F: Fn() -> xfs::XfsError + Send + 'static
+        pub fn with_read_error<P: Into<PathBuf>, F>(&mut self, path: P, f: F)
+        where
+            F: Fn() -> xfs::XfsError + Send + 'static,
         {
             self.expect_reader_if_exists()
-            .with(predicate::eq(path.into()))
-            .returning(move |_| Err(f()));
+                .with(predicate::eq(path.into()))
+                .returning(move |_| Err(f()));
         }
     }
 
@@ -174,10 +177,7 @@ pub mod test {
         let history =
             file_history(fs.clone(), event_log.clone(), &project_root, &file_path).unwrap();
 
-        assert_eq!(
-            history,
-            vec![]
-        );
+        assert_eq!(history, vec![]);
 
         fs.lock().unwrap().checkpoint();
         event_log.lock().unwrap().checkpoint();
@@ -302,7 +302,9 @@ pub mod test {
         let project_root = PathBuf::from("project_root");
         let file_path = PathBuf::from("tofu.txt");
 
-        fs.with_read_error(project_root.join(&file_path), || xfs::XfsError::UnspecifiedError("Filesystem is a teapot".to_string()));
+        fs.with_read_error(project_root.join(&file_path), || {
+            xfs::XfsError::UnspecifiedError("Filesystem is a teapot".to_string())
+        });
 
         event_log
             .expect_get_file_history()
@@ -311,8 +313,7 @@ pub mod test {
 
         let fs = Arc::new(Mutex::new(fs));
         let event_log = Arc::new(Mutex::new(event_log));
-        let history =
-            file_history(fs.clone(), event_log.clone(), &project_root, &file_path);
+        let history = file_history(fs.clone(), event_log.clone(), &project_root, &file_path);
 
         let e = history.err().unwrap();
 
@@ -340,15 +341,11 @@ pub mod test {
 
         let fs = Arc::new(Mutex::new(fs));
         let event_log = Arc::new(Mutex::new(event_log));
-        let history =
-            file_history(fs.clone(), event_log.clone(), &project_root, &file_path);
+        let history = file_history(fs.clone(), event_log.clone(), &project_root, &file_path);
 
         let e = history.err().unwrap();
 
-        assert_eq!(
-            format!("{}", e.to_string()),
-            "Event Log chopped down...",
-        );
+        assert_eq!(format!("{}", e.to_string()), "Event Log chopped down...",);
 
         fs.lock().unwrap().checkpoint();
         event_log.lock().unwrap().checkpoint();

--- a/src/file_history.rs
+++ b/src/file_history.rs
@@ -1,0 +1,283 @@
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use crate::{binary16::ContentHash, event_log::EventLog, events::EventType};
+
+#[derive(Debug, PartialEq)]
+pub struct EventLogCommand(pub String);
+
+#[derive(Debug, PartialEq)]
+pub enum FileHistoryEntry {
+    Deleted,
+    DeletedBy(EventLogCommand),
+    UnknownHash(ContentHash),
+    StoredHash(ContentHash, EventLogCommand),
+    LocalChanges(ContentHash),
+}
+
+pub fn file_history(
+    fs: Arc<Mutex<dyn xfs::Xfs>>,
+    event_log: Arc<Mutex<dyn EventLog>>,
+    project_root: &Path,
+    file_path: &Path,
+) -> anyhow::Result<Vec<FileHistoryEntry>> {
+    let mut entries = vec![];
+    let events = event_log.lock().unwrap().get_file_history(file_path)?;
+    let mut last_write_hash = None;
+    for e in events {
+        match e.event_type {
+            EventType::WriteFile(write_file_event) => {
+                if write_file_event.before_hash != last_write_hash {
+                    if let Some(hash) = write_file_event.before_hash {
+                        entries.push(FileHistoryEntry::UnknownHash(hash));
+                    } else {
+                        entries.push(FileHistoryEntry::Deleted);
+                    }
+                }
+                let group = event_log.lock().unwrap().get_event_group(e.group_id)?;
+                if let Some(hash) = &write_file_event.after_hash {
+                    entries.push(FileHistoryEntry::StoredHash(
+                        hash.clone(),
+                        EventLogCommand(group.unwrap().command),
+                    ));
+                } else {
+                    entries.push(FileHistoryEntry::DeletedBy(EventLogCommand(
+                        group.unwrap().command,
+                    )));
+                }
+                last_write_hash = write_file_event.after_hash;
+            }
+            EventType::ReadFile(_read_file_event) => {}
+            EventType::GetMetadata(_get_metadata_event) => {}
+            EventType::SetMetadata(set_metadata_event) => eprint!("{:?}", set_metadata_event),
+        }
+    }
+    // Now check the actual file
+    let cur_hash = if let Some(mut reader) = fs
+        .lock()
+        .unwrap()
+        .reader_if_exists(&project_root.join(file_path))?
+    {
+        let mut buf = vec![];
+        reader.read_to_end(&mut buf)?;
+        Some(ContentHash::from_content(&buf))
+    } else {
+        None
+    };
+    if cur_hash != last_write_hash {
+        if let Some(hash) = cur_hash {
+            entries.push(FileHistoryEntry::LocalChanges(hash));
+        } else {
+            entries.push(FileHistoryEntry::Deleted)
+        }
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+pub mod test {
+    use std::{
+        io::Cursor,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+    };
+
+    use mockall::{mock, predicate};
+
+    use crate::{
+        binary16::ContentHash,
+        event_log::test_utils::MockEventLog,
+        events::{Event, EventGroup, WriteFileEvent},
+        file_history::{EventLogCommand, FileHistoryEntry},
+    };
+
+    use super::file_history;
+
+    //TODO: Move this somewhere we can reuse it.
+    mock! {
+
+        pub Fs {}
+
+        impl xfs::Xfs for Fs {
+            fn on_each_entry(
+                &self,
+                p: &std::path::Path,
+                f: &mut dyn FnMut(&dyn xfs::Xfs, &dyn xfs::XfsDirEntry) -> anyhow::Result<()>,
+            ) -> anyhow::Result<()>;
+
+            fn on_each_entry_mut(
+                &mut self,
+                p: &std::path::Path,
+                f: &mut dyn FnMut(&mut dyn xfs::Xfs, &dyn xfs::XfsDirEntry) -> anyhow::Result<()>,
+            ) -> anyhow::Result<()>;
+
+            fn reader(&self, p: &std::path::Path) -> xfs::Result<Box<dyn std::io::Read>>;
+            fn reader_if_exists(&self, p: &std::path::Path) -> xfs::Result<Option<Box<dyn std::io::Read>>>;
+            fn writer(&mut self, p: &std::path::Path) -> xfs::Result<Box<dyn std::io::Write>>;
+            fn create_dir(&mut self, p: &std::path::Path) -> xfs::Result<()>;
+            fn create_dir_all(&mut self, p: &std::path::Path) -> xfs::Result<()>;
+            fn read_all_lines(&self, p: &std::path::Path) -> xfs::Result<Vec<String>>;
+            fn metadata(&self, p: &std::path::Path) -> xfs::Result<Box<dyn xfs::XfsMetadata>>;
+            fn tree(&self) -> String;
+            fn canonicalize(&self, p: &std::path::Path) -> xfs::Result<std::path::PathBuf>;
+            fn copy(&mut self, src_path: &std::path::Path, dst_path: &std::path::Path) -> xfs::Result<()>;
+            fn is_dir(&self, p: &std::path::Path) -> bool;
+            fn is_file(&self, p: &std::path::Path) -> bool;
+            fn exists(&self, p: &std::path::Path) -> bool;
+        }
+
+    }
+
+    impl MockFs {
+        pub fn with_read<P: Into<PathBuf>, B: Into<Vec<u8>>>(&mut self, path: P, content: B) {
+            let content = Box::new(Cursor::new(content.into()));
+            self.expect_reader_if_exists()
+                .with(predicate::eq(path.into()))
+                .returning(move |_| Ok(Some(content.clone())));
+        }
+
+        pub fn with_missing_read<P: Into<PathBuf>>(&mut self, path: P) {
+            self.expect_reader_if_exists()
+                .with(predicate::eq(path.into()))
+                .returning(move |_| Ok(None));
+        }
+    }
+
+    #[test]
+    pub fn untracked_nonexistant_file() {
+        todo!()
+    }
+
+    #[test]
+    pub fn normal_file() {
+        let mut fs = MockFs::default();
+        let mut event_log = MockEventLog::default();
+
+        let project_root = PathBuf::from("project_root");
+        let file_path = PathBuf::from("tofu.txt");
+
+        let file_original_content = b"This is a test";
+        let file_local_chages_content = b"Hello World";
+        fs.with_read(project_root.join(&file_path), file_local_chages_content);
+
+        let mock_events: Vec<Event> = vec![Event::from(WriteFileEvent {
+            path: project_root.join(&file_path),
+            before_hash: None,
+            after_hash: Some(ContentHash::from_content(file_original_content)),
+        })
+        .with_group_id(12)];
+
+        let event_group = EventGroup {
+            id: 12,
+            command: "dancing".to_string(),
+            events: vec![],
+            is_most_recent_run: false,
+        };
+
+        event_log
+            .expect_get_file_history()
+            .with(predicate::eq(file_path.clone()))
+            .returning(move |_| Ok(mock_events.clone()));
+        event_log
+            .expect_get_event_group()
+            .with(predicate::eq(12u64))
+            .returning(move |_| Ok(Some(event_group.clone())));
+
+        let fs = Arc::new(Mutex::new(fs));
+        let event_log = Arc::new(Mutex::new(event_log));
+        let history =
+            file_history(fs.clone(), event_log.clone(), &project_root, &file_path).unwrap();
+
+        assert_eq!(
+            history,
+            vec![
+                FileHistoryEntry::StoredHash(
+                    ContentHash::from_content(file_original_content),
+                    EventLogCommand("dancing".to_string())
+                ),
+                FileHistoryEntry::LocalChanges(ContentHash::from_content(
+                    file_local_chages_content
+                ))
+            ]
+        );
+
+        fs.lock().unwrap().checkpoint();
+        event_log.lock().unwrap().checkpoint();
+    }
+
+    #[test]
+    pub fn removed_file() {
+        let mut fs = MockFs::default();
+        let mut event_log = MockEventLog::default();
+
+        let project_root = PathBuf::from("project_root");
+        let file_path = PathBuf::from("tofu.txt");
+
+        let file_original_content = b"This is a test";
+        fs.with_missing_read(project_root.join(&file_path));
+
+        let mock_events: Vec<Event> = vec![Event::from(WriteFileEvent {
+            path: project_root.join(&file_path),
+            before_hash: None,
+            after_hash: Some(ContentHash::from_content(file_original_content)),
+        })
+        .with_group_id(12)];
+
+        let event_group = EventGroup {
+            id: 12,
+            command: "dancing".to_string(),
+            events: vec![],
+            is_most_recent_run: false,
+        };
+
+        event_log
+            .expect_get_file_history()
+            .with(predicate::eq(file_path.clone()))
+            .returning(move |_| Ok(mock_events.clone()));
+        event_log
+            .expect_get_event_group()
+            .with(predicate::eq(12u64))
+            .returning(move |_| Ok(Some(event_group.clone())));
+
+        let fs = Arc::new(Mutex::new(fs));
+        let event_log = Arc::new(Mutex::new(event_log));
+        let history =
+            file_history(fs.clone(), event_log.clone(), &project_root, &file_path).unwrap();
+
+        assert_eq!(
+            history,
+            vec![
+                FileHistoryEntry::StoredHash(
+                    ContentHash::from_content(file_original_content),
+                    EventLogCommand("dancing".to_string())
+                ),
+                FileHistoryEntry::Deleted,
+            ]
+        );
+
+        fs.lock().unwrap().checkpoint();
+        event_log.lock().unwrap().checkpoint();
+    }
+
+    #[test]
+    pub fn called_on_directory() {
+        todo!();
+    }
+
+    #[test]
+    pub fn file_became_directory() {
+        todo!();
+    }
+
+    #[test]
+    pub fn handles_filesystem_error() {
+        todo!();
+    }
+
+    #[test]
+    pub fn handles_event_log_errors() {
+        todo!();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ pub mod events;
 pub mod fs_utils;
 pub mod llm;
 pub mod metadata;
+pub mod mock;
 pub mod scripting_luau;
 
 use binary16::ContentHash;
@@ -29,7 +30,6 @@ use llm::{InvalidLLM, OpenAILLM, LLM};
 use metadata::MetadataEntry;
 use metadata::MetadataKey;
 use scripting_luau::run_script;
-use serde_json::json;
 use xfs::Xfs;
 
 pub struct Wrought {
@@ -281,7 +281,7 @@ fn cmd_init(cmd: &InitCmd) -> anyhow::Result<()> {
         .unwrap()
         .writer(&path.join(".wrought").join("settings.toml"))?;
     writer.write_all(
-        vec![
+        [
             "# General Project Settings",
             "",
             "# LLM Settings",
@@ -509,7 +509,7 @@ pub fn create_backend(path: &Path) -> anyhow::Result<Arc<Mutex<dyn Backend>>> {
         content_storage_path,
     )));
     Ok(Arc::new(Mutex::new(DummyBackend {
-        fs: fs,
+        fs,
         root: path,
         content_store,
     })))
@@ -638,7 +638,7 @@ fn get_absolute_project_and_relative_file(
 }
 
 fn cmd_history(
-    cmd: HistoryCmd,
+    _cmd: HistoryCmd,
     fs: Arc<Mutex<dyn xfs::Xfs>>,
     event_log: Arc<Mutex<dyn EventLog>>,
     project_root: &Path,
@@ -665,8 +665,8 @@ fn cmd_history(
                 );
                 last_write_hash = write_file_event.after_hash;
             }
-            EventType::ReadFile(read_file_event) => {}
-            EventType::GetMetadata(get_metadata_event) => {}
+            EventType::ReadFile(_read_file_event) => {}
+            EventType::GetMetadata(_get_metadata_event) => {}
             EventType::SetMetadata(set_metadata_event) => eprint!("{:?}", set_metadata_event),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,7 +416,7 @@ impl PackageDirectory {
     fn packages(&self, fs: &dyn xfs::Xfs) -> Vec<anyhow::Result<Package>> {
         let mut result = vec![];
 
-        let mut f = |fs: &dyn Xfs, entry: &dyn xfs::XfsDirEntry| -> anyhow::Result<()> {
+        let mut f = |_fs: &dyn Xfs, entry: &dyn xfs::XfsDirEntry| -> anyhow::Result<()> {
             let md = match entry.metadata() {
                 Err(e) => {
                     result.push(
@@ -650,12 +650,12 @@ fn cmd_history(
         match e {
             FileHistoryEntry::Deleted => eprintln!("- nothing"),
             FileHistoryEntry::DeletedBy(cmd) => eprintln!("+ nothing : {}", cmd.0),
-            FileHistoryEntry::UnknownHash(hash) => eprintln!("- {} : ???", hash.to_string()),
+            FileHistoryEntry::UnknownHash(hash) => eprintln!("- {} : ???", hash),
             FileHistoryEntry::StoredHash(hash, cmd) => {
-                eprintln!("+ {} : {}", hash.to_string(), cmd.0)
+                eprintln!("+ {} : {}", hash, cmd.0)
             }
             FileHistoryEntry::LocalChanges(hash) => {
-                eprintln!("- {} : local changes", hash.to_string())
+                eprintln!("- {} : local changes", hash)
             }
         }
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MetadataKey {
     StringKey(String),
 }
@@ -17,7 +17,7 @@ impl From<&str> for MetadataKey {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MetadataEntry {
     value: String,
 }


### PR DESCRIPTION
Reordered and squashed and landed as

* fbe866d added tests for file history internals
* 9df7c47 switching to mockall for mocking and mocked event_log so we can start testing file-history functions